### PR TITLE
Fix stack initialization in VM

### DIFF
--- a/src/lita/vm.c
+++ b/src/lita/vm.c
@@ -221,9 +221,9 @@ void vmSwap(u8 a, u8 b) {
  *     receiver-^               ^-stackTop
  */
 CallFrame *newFrame(Obj *obj, usize slots) {
-  CallFrame *existingFrame = CURRENT_FRAME;
+  CallFrame *existingFrame = vm.frameCount ? CURRENT_FRAME : NULL;
 
-  if (existingFrame->obj == obj && existingFrame->ip &&
+  if (existingFrame && existingFrame->obj == obj && existingFrame->ip &&
       *(existingFrame->ip) == OP_RETURN) {
     // Tail-call optimization.
     copyValues(vm.stackTop - slots, existingFrame->slots, slots);
@@ -859,6 +859,9 @@ static InterpretResult runClosure(ObjClosure *closure) {
 
 InterpretResult runFunction(ObjFunction *fun) {
   if (fun == NULL) return INTERPRET_COMPILE_ERROR;
+
+  // Ensure we start with a clean stack.
+  resetStack();
 
   push(OBJ_VAL(fun));
   ObjClosure *closure = newClosure(fun);


### PR DESCRIPTION
## Summary
- avoid referencing non-existent frame in `newFrame`
- reset the VM stack when starting a new function

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686d75fec7008323aec6e134bd89218d